### PR TITLE
Remove radar timer & logic, add new Valve built-in cvar

### DIFF
--- a/cfg/sourcemod/multi1v1/game_cvars.cfg
+++ b/cfg/sourcemod/multi1v1/game_cvars.cfg
@@ -25,6 +25,7 @@ mp_teamcashawards 0
 mp_warmuptime 5
 sv_competitive_official_5v5 0
 sv_ignoregrenaderadio 1
+sv_disable_radar 1
 
 
 // Game cvars you may want to change:

--- a/scripting/multi1v1.sp
+++ b/scripting/multi1v1.sp
@@ -925,8 +925,6 @@ public Action Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroad
     return;
   }
 
-  CreateTimer(0.1, RemoveRadar, client);
-
   Call_StartForward(g_hAfterPlayerSpawn);
   Call_PushCell(client);
   Call_Finish();

--- a/scripting/multi1v1/generic.sp
+++ b/scripting/multi1v1/generic.sp
@@ -1,5 +1,4 @@
 #define MESSAGE_PREFIX "[\x05Multi1v1\x01] "
-#define HIDE_RADAR_BIT 1 << 12
 #define DEBUG_CVAR "sm_multi1v1_debug"
 #define INTEGER_STRING_LENGTH 20  // max number of digits a 64-bit integer can use up as a string
 // this is for converting ints to strings when setting menu values/cookies
@@ -16,17 +15,6 @@ char g_ColorCodes[][] = {"\x01", "\x02", "\x03", "\x04", "\x05", "\x06",
 #define SPECMODE_FIRSTPERSON 4
 #define SPECMODE_THIRDPERSON 5
 #define SPECMODE_FREELOOK 6
-
-/**
- * Removes the radar element from a client's HUD.
- */
-public Action RemoveRadar(Handle timer, int client) {
-  if (IsValidClient(client) && !IsFakeClient(client)) {
-    int flags = GetEntProp(client, Prop_Send, "m_iHideHUD");
-    SetEntProp(client, Prop_Send, "m_iHideHUD", flags | (HIDE_RADAR_BIT));
-  }
-  return Plugin_Continue;
-}
 
 /**
  * Function to identify if a client is valid and in game.


### PR DESCRIPTION
This PR replaces the current logic which removes the radar for players. Valve introduced a cvar a few updates back (sv_disable_radar) which would replace this function, resulting in a tiny optimization, but also allows server owners to choose if they want to use radar or not, instead of being hardcoded.

I've included the new cvar in the game_cvars.cfg config file to replicate original behavior.