### PR TITLE
Add a native to detect if the 1v1 plugin is allowing rating changes based on the config values

### DIFF
--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -412,10 +412,16 @@ native int Multi1v1_GetRoundTypeIndex(const char[] internalName);
 // Helper null callback for round types that don't need to give players weapons on spawn.
 public void Multi1v1_NullWeaponHandler(int client) {}
 
+
+/**
+ * Returns if the plugin will do rating updates ( based on the config value sm_multi1v1_min_players_for_rating_changes )
+ */
+native bool Multi1v1_AreRatingChangesAllowed();
 native bool Multi1v1_IsRoundTypeEnabled(int roundType);
 native void Multi1v1_EnableRoundType(int roundType);
 native void Multi1v1_DisableRoundType(int roundType);
 native void Multi1v1_GetRoundTypeDisplayName(int roundType, char[] buffer, int bufferLength);
+
 
 /**
  * Returns the current round type in an arena.
@@ -514,6 +520,7 @@ public __pl_multi1v1_SetNTVOptional() {
   MarkNativeAsOptional("Multi1v1_PlayerAllowsRoundType");
   MarkNativeAsOptional("Multi1v1_PlayerPreference");
   MarkNativeAsOptional("Multi1v1_IsHidingStats");
+  MarkNativeAsOptional("Multi1v1_AreRatingChangesAllowed");
   MarkNativeAsOptional("Multi1v1_IsRoundTypeEnabled");
   MarkNativeAsOptional("Multi1v1_EnableRoundType");
   MarkNativeAsOptional("Multi1v1_DisableRoundType");

--- a/scripting/multi1v1/natives.sp
+++ b/scripting/multi1v1/natives.sp
@@ -55,6 +55,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_PlayerAllowsRoundType", Native_PlayerAllowsRoundType);
   CreateNative("Multi1v1_PlayerPreference", Native_PlayerPreference);
   CreateNative("Multi1v1_IsHidingStats", Native_IsHidingStates);
+  CreateNative("Multi1v1_AreRatingChangesAllowed", Native_AreRatingChangesAllowed);
   CreateNative("Multi1v1_IsRoundTypeEnabled", Native_IsRoundTypeEnabled);
   CreateNative("Multi1v1_EnableRoundType", Native_EnableRoundType);
   CreateNative("Multi1v1_DisableRoundType", Native_DisableRoundType);
@@ -462,6 +463,10 @@ public int Native_IsHidingStates(Handle plugin, int numParams) {
   int client = GetNativeCell(1);
   CHECK_CONNECTED(client);
   return g_HideStats[client];
+}
+
+public int Native_AreRatingChangesAllowed(Handle plugin, int numParams) {  
+  return AreRatingChangesAllowed();
 }
 
 public int Native_IsRoundTypeEnabled(Handle plugin, int numParams) {

--- a/scripting/multi1v1/stats.sp
+++ b/scripting/multi1v1/stats.sp
@@ -267,7 +267,7 @@ public void Increment(int client, const char[] field) {
  * Fetches, if needed, and calculates the relevent players' new ratings.
  */
 static void UpdateRatings(int winner, int loser, bool forceLoss, int roundType) {
-  if (db != INVALID_HANDLE && CountActivePlayers() >= g_MinPlayersForRatingChangesCvar.IntValue) {
+  if (db != INVALID_HANDLE && AreRatingChangesAllowed()) {
     // go fetch the ratings if needed
     if (!g_FetchedPlayerInfo[winner]) {
       DB_FetchRatings(winner);
@@ -352,4 +352,8 @@ static int CountActivePlayers() {
     }
   }
   return count;
+}
+
+public bool AreRatingChangesAllowed() {
+  return CountActivePlayers() >= g_MinPlayersForRatingChangesCvar.IntValue;
 }


### PR DESCRIPTION
Example: 

1. People want to write a plugin that changes score if the player delayed the round again for the 4th time.
2. If 2 players are AFK, they will be delaying a couple of rounds in a row.
3. The server has set sm_multi1v1_min_players_for_rating_changes to 4.
4. Plugins can now poll the 1v1 plugin to see if they are allowed to change the score values.