### PR TITLE
Expose internal HasRoundTypeSpecificRating via Natives

### DIFF
--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -404,6 +404,9 @@ native void Multi1v1_ClearRoundTypes();
  */
 native void Multi1v1_AddStandardRounds();
 
+
+native bool Multi1v1_HasRoundTypeSpecificRating(int roundType);
+
 /**
  * Returns the unique identifier (the index) of a round type given its internal name.
  */
@@ -507,6 +510,7 @@ public __pl_multi1v1_SetNTVOptional() {
   MarkNativeAsOptional("Multi1v1_GetPistolChoice");
   MarkNativeAsOptional("Multi1v1_AddRoundType");
   MarkNativeAsOptional("Multi1v1_ClearRoundTypes");
+  MarkNativeAsOptional("Multi1v1_HasRoundTypeSpecificRating");
   MarkNativeAsOptional("Multi1v1_GetRoundTypeIndex");
   MarkNativeAsOptional("Multi1v1_AddStandardRounds");
   MarkNativeAsOptional("Multi1v1_GetCurrentRoundType");

--- a/scripting/multi1v1/natives.sp
+++ b/scripting/multi1v1/natives.sp
@@ -46,6 +46,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_FindArenaNumber", Native_FindArenaNumber);
   CreateNative("Multi1v1_GetRifleChoice", Native_GetRifleChoice);
   CreateNative("Multi1v1_GetPistolChoice", Native_GetPistolChoice);
+  CreateNative("Multi1v1_HasRoundTypeSpecificRating", Native_HasRoundTypeSpecificRating);
   CreateNative("Multi1v1_GetRoundTypeIndex", Native_GetRoundTypeIndex);
   CreateNative("Multi1v1_AddRoundType", Native_AddRoundType);
   CreateNative("Multi1v1_ClearRoundTypes", Native_ClearRoundTypes);
@@ -415,6 +416,12 @@ public int Native_AddRoundType(Handle plugin, int numParams) {
   return AddRoundType(plugin, displayName, internalName, weaponHandler, optional, ranked,
                       ratingFieldName, enabled);
 }
+
+public int Native_HasRoundTypeSpecificRating(Handle plugin, int numParams) {
+  int roundType = GetNativeCell(1);
+  CHECK_ROUNDTYPE(roundType);
+  return HasRoundTypeSpecificRating(roundType);
+}  
 
 public int Native_GetRoundTypeIndex(Handle plugin, int numParams) {
   char buffer[ROUND_TYPE_NAME_LENGTH];

--- a/scripting/multi1v1/stats.sp
+++ b/scripting/multi1v1/stats.sp
@@ -333,7 +333,7 @@ static void ForceLossMessage(int client, float rating, float delta) {
     Multi1v1_Message(client, "%t", "TimeRanOut", RoundToNearest(rating), delta);
 }
 
-static bool HasRoundTypeSpecificRating(int roundType) {
+public bool HasRoundTypeSpecificRating(int roundType) {
   return g_RoundTypeRanked[roundType] && !StrEqual(g_RoundTypeFieldNames[roundType], "");
 }
 


### PR DESCRIPTION
Allow plugins to check if the current round is ranked or not.

This allows plugins to check if they may modify scoring.
This allows plugins to introduce fun things like low gravity. (we don't want to give gravity on ranked rounds)