### PR TITLE
Move defines to the multi1v1 include to allow other plugins to use the same compiled K_FACTOR

### DIFF
--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -4,6 +4,8 @@
 #endif
 #define _multi1v1_included
 
+#define DISTRIBUTION_SPREAD 1000.0
+#define K_FACTOR 8.0
 #define WEAPON_NAME_LENGTH 32
 #define MAX_ROUND_TYPES 32
 

--- a/scripting/multi1v1.sp
+++ b/scripting/multi1v1.sp
@@ -27,8 +27,6 @@
  *                     *
  ***********************/
 
-#define DISTRIBUTION_SPREAD 1000.0
-#define K_FACTOR 8.0
 #define ROUND_TYPE_NAME_LENGTH 64
 #define DATABASE_CONFIG_NAME "multi1v1"
 #define TABLE_NAME "multi1v1_stats"


### PR DESCRIPTION
Move defines to the multi1v1 include to allow other plugins to use the same compiled K_FACTOR
That or we expose it via a native (but KISS rule :) ) 