### PR TITLE
New natives to check states + renaming + bugfix

### DIFF
--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -410,7 +410,6 @@ native void Multi1v1_AddStandardRounds();
 
 /**
  * Returns if the given round type is ranked.
- *
  */
 native bool Multi1v1_IsRoundTypeRanked(int roundType);
 

--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -542,3 +542,4 @@ public void __pl_multi1v1_SetNTVOptional() {
   MarkNativeAsOptional("Multi1v1_GetRoundTypeDisplayName");
   MarkNativeAsOptional("Multi1v1_GivePlayerKnife");
 }
+#endif

--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -413,6 +413,9 @@ native void Multi1v1_AddStandardRounds();
  */
 native bool Multi1v1_IsRoundTypeRanked(int roundType);
 
+#pragma deprecated Use the Multi1v1_IsRoundTypeRanked() instead
+native bool Multi1v1_HasRoundTypeSpecificRating(int roundType);
+
 /**
  * Returns the unique identifier (the index) of a round type given its internal name.
  */

--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -289,12 +289,16 @@ native void Multi1v1_GivePlayerArenaWeapons(int client, int roundType);
 // 'you are in arena %d facing off against %N' using these.
 native void Multi1v1_BlockRatingChanges(int client);
 native void Multi1v1_UnblockRatingChanges(int client);
+native void Multi1v1_AreRatingChangesBlocked(int client);
 native void Multi1v1_BlockChatMessages(int client);
 native void Multi1v1_UnblockChatMessages(int client);
+native void Multi1v1_AreChatMessagesBlocked(int client);
 native void Multi1v1_BlockMVPStars(int client);
 native void Multi1v1_UnblockMVPStars(int client);
+native void Multi1v1_AreMVPStarsBlocked(int client);
 native void Multi1v1_BlockArenaDones(int arena);
 native void Multi1v1_UnblockArenaDones(int arena);
+native void Multi1v1_AreArenaDonesBlocked(int arena);
 
 /**
  * Sets an offset value for arena numbering when giving
@@ -404,8 +408,11 @@ native void Multi1v1_ClearRoundTypes();
  */
 native void Multi1v1_AddStandardRounds();
 
-
-native bool Multi1v1_HasRoundTypeSpecificRating(int roundType);
+/**
+ * Returns if the given round type is ranked.
+ *
+ */
+native bool Multi1v1_IsRoundTypeRanked(int roundType);
 
 /**
  * Returns the unique identifier (the index) of a round type given its internal name.
@@ -501,12 +508,16 @@ public void __pl_multi1v1_SetNTVOptional() {
   MarkNativeAsOptional("Multi1v1_MessageToAll");
   MarkNativeAsOptional("Multi1v1_BlockRatingChanges");
   MarkNativeAsOptional("Multi1v1_UnblockRatingChanges");
+  MarkNativeAsOptional("Multi1v1_AreRatingChangesBlocked");
   MarkNativeAsOptional("Multi1v1_BlockChatMessages");
   MarkNativeAsOptional("Multi1v1_UnblockChatMessages");
+  MarkNativeAsOptional("Multi1v1_AreChatMessagesBlocked");
   MarkNativeAsOptional("Multi1v1_BlockMVPStars");
   MarkNativeAsOptional("Multi1v1_UnblockMVPStars");
+  MarkNativeAsOptional("Multi1v1_AreMVPStarsBlocked");
   MarkNativeAsOptional("Multi1v1_BlockArenaDones");
   MarkNativeAsOptional("Multi1v1_UnblockArenaDones");
+  MarkNativeAsOptional("Multi1v1_AreArenaDonesBlocked");
   MarkNativeAsOptional("Multi1v1_SetArenaOffsetValue");
   MarkNativeAsOptional("Multi1v1_ELORatingDelta");
   MarkNativeAsOptional("Multi1v1_GetNumSpawnsInArena");
@@ -516,7 +527,7 @@ public void __pl_multi1v1_SetNTVOptional() {
   MarkNativeAsOptional("Multi1v1_GetPistolChoice");
   MarkNativeAsOptional("Multi1v1_AddRoundType");
   MarkNativeAsOptional("Multi1v1_ClearRoundTypes");
-  MarkNativeAsOptional("Multi1v1_HasRoundTypeSpecificRating");
+  MarkNativeAsOptional("Multi1v1_IsRoundTypeRanked");
   MarkNativeAsOptional("Multi1v1_GetRoundTypeIndex");
   MarkNativeAsOptional("Multi1v1_AddStandardRounds");
   MarkNativeAsOptional("Multi1v1_GetCurrentRoundType");
@@ -532,4 +543,3 @@ public void __pl_multi1v1_SetNTVOptional() {
   MarkNativeAsOptional("Multi1v1_GetRoundTypeDisplayName");
   MarkNativeAsOptional("Multi1v1_GivePlayerKnife");
 }
-#endif

--- a/scripting/include/multi1v1.inc
+++ b/scripting/include/multi1v1.inc
@@ -530,6 +530,7 @@ public void __pl_multi1v1_SetNTVOptional() {
   MarkNativeAsOptional("Multi1v1_AddRoundType");
   MarkNativeAsOptional("Multi1v1_ClearRoundTypes");
   MarkNativeAsOptional("Multi1v1_IsRoundTypeRanked");
+  MarkNativeAsOptional("Multi1v1_HasRoundTypeSpecificRating");
   MarkNativeAsOptional("Multi1v1_GetRoundTypeIndex");
   MarkNativeAsOptional("Multi1v1_AddStandardRounds");
   MarkNativeAsOptional("Multi1v1_GetCurrentRoundType");

--- a/scripting/multi1v1/natives.sp
+++ b/scripting/multi1v1/natives.sp
@@ -34,6 +34,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_BlockRatingChanges", Native_BlockRatingChanges);
   CreateNative("Multi1v1_UnblockRatingChanges", Native_UnblockRatingChanges);
   CreateNative("Multi1v1_AreRatingChangesBlocked", Native_AreRatingChangesBlocked);
+  CreateNative("Multi1v1_HasRoundTypeSpecificRating", Native_HasRoundTypeSpecificRating);
   CreateNative("Multi1v1_BlockChatMessages", Native_BlockChatMessages);
   CreateNative("Multi1v1_UnblockChatMessages", Native_UnblockChatMessages);
   CreateNative("Multi1v1_AreChatMessagesBlocked", Native_AreChatMessagesBlocked);

--- a/scripting/multi1v1/natives.sp
+++ b/scripting/multi1v1/natives.sp
@@ -33,12 +33,16 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_MessageToAll", Native_Multi1v1MessageToAll);
   CreateNative("Multi1v1_BlockRatingChanges", Native_BlockRatingChanges);
   CreateNative("Multi1v1_UnblockRatingChanges", Native_UnblockRatingChanges);
+  CreateNative("Multi1v1_AreRatingChangesBlocked", Native_AreRatingChangesBlocked);
   CreateNative("Multi1v1_BlockChatMessages", Native_BlockChatMessages);
   CreateNative("Multi1v1_UnblockChatMessages", Native_UnblockChatMessages);
+  CreateNative("Multi1v1_AreChatMessagesBlocked", Native_AreChatMessagesBlocked);
   CreateNative("Multi1v1_BlockMVPStars", Native_BlockMVPStars);
   CreateNative("Multi1v1_UnblockMVPStars", Native_UnblockMVPStars);
+  CreateNative("Multi1v1_AreMVPStarsBlocked", Native_AreMVPStarsBlocked);
   CreateNative("Multi1v1_BlockArenaDones", Native_BlockArenaDones);
   CreateNative("Multi1v1_UnblockArenaDones", Native_UnblockArenaDones);
+  CreateNative("Multi1v1_Native_AreArenaDonesBlocked", Native_AreArenaDonesBlocked);
   CreateNative("Multi1v1_SetArenaOffsetValue", Native_SetArenaOffsetValue);
   CreateNative("Multi1v1_ELORatingDelta", Native_ELORatingDelta);
   CreateNative("Multi1v1_GetNumSpawnsInArena", Native_GetNumSpawnsInArena);
@@ -46,7 +50,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_FindArenaNumber", Native_FindArenaNumber);
   CreateNative("Multi1v1_GetRifleChoice", Native_GetRifleChoice);
   CreateNative("Multi1v1_GetPistolChoice", Native_GetPistolChoice);
-  CreateNative("Multi1v1_HasRoundTypeSpecificRating", Native_HasRoundTypeSpecificRating);
+  CreateNative("Multi1v1_IsRoundTypeRanked", Native_IsRoundTypeRanked);
   CreateNative("Multi1v1_GetRoundTypeIndex", Native_GetRoundTypeIndex);
   CreateNative("Multi1v1_AddRoundType", Native_AddRoundType);
   CreateNative("Multi1v1_ClearRoundTypes", Native_ClearRoundTypes);
@@ -55,7 +59,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_GetNumRoundTypes", Native_GetNumRoundTypes);
   CreateNative("Multi1v1_PlayerAllowsRoundType", Native_PlayerAllowsRoundType);
   CreateNative("Multi1v1_PlayerPreference", Native_PlayerPreference);
-  CreateNative("Multi1v1_IsHidingStats", Native_IsHidingStates);
+  CreateNative("Multi1v1_IsHidingStats", Native_IsHidingStats);
   CreateNative("Multi1v1_AreRatingChangesAllowed", Native_AreRatingChangesAllowed);
   CreateNative("Multi1v1_IsRoundTypeEnabled", Native_IsRoundTypeEnabled);
   CreateNative("Multi1v1_EnableRoundType", Native_EnableRoundType);
@@ -102,7 +106,7 @@ public int Native_GetRating(Handle plugin, int numParams) {
     return view_as<int>(g_Rating[client]);
   } else {
     CHECK_ROUNDTYPE(roundType);
-    if (g_RoundTypeRanked[roundType])
+    if (!HasRoundTypeSpecificRating(roundType))
       ThrowNativeError(SP_ERROR_PARAM, "Roundtype %d is not ranked", roundType);
 
     return view_as<int>(g_RoundTypeRating[client][roundType]);
@@ -257,6 +261,13 @@ public int Native_UnblockRatingChanges(Handle plugin, int numParams) {
   g_BlockStatChanges[client] = false;
 }
 
+public int Native_AreRatingChangesBlocked(Handle plugin, int numParams) {
+  int client = GetNativeCell(1);
+  CHECK_CONNECTED(client);
+  return g_BlockStatChanges[client];
+}
+
+
 public int Native_BlockChatMessages(Handle plugin, int numParams) {
   int client = GetNativeCell(1);
   CHECK_CONNECTED(client);
@@ -267,6 +278,12 @@ public int Native_UnblockChatMessages(Handle plugin, int numParams) {
   int client = GetNativeCell(1);
   CHECK_CONNECTED(client);
   g_BlockChatMessages[client] = false;
+}
+
+public int Native_AreChatMessagesBlocked(Handle plugin, int numParams) {
+  int client = GetNativeCell(1);
+  CHECK_CONNECTED(client);
+  return g_BlockChatMessages[client];
 }
 
 public int Native_BlockMVPStars(Handle plugin, int numParams) {
@@ -281,6 +298,12 @@ public int Native_UnblockMVPStars(Handle plugin, int numParams) {
   g_BlockMVPStars[client] = false;
 }
 
+public int Native_AreMVPStarsBlocked(Handle plugin, int numParams) {
+  int client = GetNativeCell(1);
+  CHECK_CONNECTED(client);
+  return g_BlockMVPStars[client];
+}
+
 public int Native_BlockArenaDones(Handle plugin, int numParams) {
   int arena = GetNativeCell(1);
   g_BlockArenaDones[arena] = true;
@@ -289,6 +312,12 @@ public int Native_BlockArenaDones(Handle plugin, int numParams) {
 public int Native_UnblockArenaDones(Handle plugin, int numParams) {
   int arena = GetNativeCell(1);
   g_BlockArenaDones[arena] = false;
+}
+
+public int Native_AreArenaDonesBlocked(Handle plugin, int numParams) {
+  int arena = GetNativeCell(1);
+  CHECK_ARENA(arena);
+  return g_BlockArenaDones[arena];
 }
 
 public int Native_SetArenaOffsetValue(Handle plugin, int numParams) {
@@ -418,7 +447,7 @@ public int Native_AddRoundType(Handle plugin, int numParams) {
                       ratingFieldName, enabled);
 }
 
-public int Native_HasRoundTypeSpecificRating(Handle plugin, int numParams) {
+public int Native_IsRoundTypeRanked(Handle plugin, int numParams) {
   int roundType = GetNativeCell(1);
   CHECK_ROUNDTYPE(roundType);
   return HasRoundTypeSpecificRating(roundType);
@@ -466,7 +495,7 @@ public int Native_PlayerPreference(Handle plugin, int numParams) {
   return g_Preference[client];
 }
 
-public int Native_IsHidingStates(Handle plugin, int numParams) {
+public int Native_IsHidingStats(Handle plugin, int numParams) {
   int client = GetNativeCell(1);
   CHECK_CONNECTED(client);
   return g_HideStats[client];

--- a/scripting/multi1v1/natives.sp
+++ b/scripting/multi1v1/natives.sp
@@ -34,7 +34,6 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_BlockRatingChanges", Native_BlockRatingChanges);
   CreateNative("Multi1v1_UnblockRatingChanges", Native_UnblockRatingChanges);
   CreateNative("Multi1v1_AreRatingChangesBlocked", Native_AreRatingChangesBlocked);
-  CreateNative("Multi1v1_HasRoundTypeSpecificRating", Native_AreRatingChangesBlocked);
   CreateNative("Multi1v1_BlockChatMessages", Native_BlockChatMessages);
   CreateNative("Multi1v1_UnblockChatMessages", Native_UnblockChatMessages);
   CreateNative("Multi1v1_AreChatMessagesBlocked", Native_AreChatMessagesBlocked);
@@ -52,6 +51,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_GetRifleChoice", Native_GetRifleChoice);
   CreateNative("Multi1v1_GetPistolChoice", Native_GetPistolChoice);
   CreateNative("Multi1v1_IsRoundTypeRanked", Native_IsRoundTypeRanked);
+  CreateNative("Multi1v1_HasRoundTypeSpecificRating", Native_IsRoundTypeRanked);
   CreateNative("Multi1v1_GetRoundTypeIndex", Native_GetRoundTypeIndex);
   CreateNative("Multi1v1_AddRoundType", Native_AddRoundType);
   CreateNative("Multi1v1_ClearRoundTypes", Native_ClearRoundTypes);

--- a/scripting/multi1v1/natives.sp
+++ b/scripting/multi1v1/natives.sp
@@ -34,7 +34,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
   CreateNative("Multi1v1_BlockRatingChanges", Native_BlockRatingChanges);
   CreateNative("Multi1v1_UnblockRatingChanges", Native_UnblockRatingChanges);
   CreateNative("Multi1v1_AreRatingChangesBlocked", Native_AreRatingChangesBlocked);
-  CreateNative("Multi1v1_HasRoundTypeSpecificRating", Native_HasRoundTypeSpecificRating);
+  CreateNative("Multi1v1_HasRoundTypeSpecificRating", Native_AreRatingChangesBlocked);
   CreateNative("Multi1v1_BlockChatMessages", Native_BlockChatMessages);
   CreateNative("Multi1v1_UnblockChatMessages", Native_UnblockChatMessages);
   CreateNative("Multi1v1_AreChatMessagesBlocked", Native_AreChatMessagesBlocked);

--- a/scripting/multi1v1/stats.sp
+++ b/scripting/multi1v1/stats.sp
@@ -226,7 +226,7 @@ public void DB_RoundUpdate(int winner, int loser, bool forceLoss) {
 
     int arena = g_Ranking[winner];
     int roundType = g_roundTypes[arena];
-    if (!g_RoundTypeRanked[roundType])
+    if (!HasRoundTypeSpecificRating(roundType))
       return;
 
     g_Losses[loser]++;


### PR DESCRIPTION
🛠️ Renamed: `Multi1v1_HasRoundTypeSpecificRating` to `Multi1v1_IsRoundTypeRanked` 
To improve readability and to avoid possible confusion with `Multi1v1_BlockRatingChanges`  and `Multi1v1_UnblockRatingChanges`


🐞 Fixed #255

Added 4 other natives to check states (for cross plugin activity)

🆕 Multi1v1_AreRatingChangesBlocked
🆕 Multi1v1_AreChatMessagesBlocked
🆕 Multi1v1_AreMVPStarsBlocked
🆕 Multi1v1_AreArenaDonesBlocked