### PR TITLE
Improve validity check for client in Event_OnPlayerDeath

### DIFF
--- a/scripting/multi1v1.sp
+++ b/scripting/multi1v1.sp
@@ -873,7 +873,7 @@ public Action Event_OnPlayerDeath(Event event, const char[] name, bool dontBroad
   int victim = GetClientOfUserId(event.GetInt("userid"));
   int attacker = GetClientOfUserId(event.GetInt("attacker"));
 
-  if (victim < 0) {
+  if (victim < 1) {
     return Plugin_Continue;
   }
 


### PR DESCRIPTION
When players disconnect this event is also fired. Since the player is no longer on the server, GetClientOfUserId fails to return a valid client - meaning it will return "0". As the client ID 0 is "console", it should be ignored in code that handles existing clients.